### PR TITLE
Backport fixes from the 1.1 branch

### DIFF
--- a/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/impl/TypedEventBusImpl.java
+++ b/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/impl/TypedEventBusImpl.java
@@ -314,17 +314,20 @@ public class TypedEventBusImpl implements TypedEventBus {
             idMap.remove(serviceId);
             if (consumed != null) {
                 consumed.forEach(s -> {
-                	Map<T, ?> handlers;
+                	Map<String, Map<T, U>> handlers;
+                	String key;
                 	if(isWildcard(s)) {
-                		handlers = wildcardMap.get(s.length() == 1 ? "" : s.substring(0, s.length() - 2));
+                		handlers = wildcardMap;
+                		key = s.length() == 1 ? "" : s.substring(0, s.length() - 2);
                 	} else {
-                		handlers = map.get(s);
+                		handlers = map;
+                		key = s;
                 	}
-                	
-                    if (handlers != null) {
-                        handlers.remove(handler);
-                        if (handlers.isEmpty()) {
-                            map.remove(s);
+                	Map<T,?> subMap = handlers.get(key);
+                    if (subMap != null) {
+                    	subMap.remove(handler);
+                        if (subMap.isEmpty()) {
+                            map.remove(key);
                         }
                     }
                 });

--- a/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/impl/TypedEventBusImpl.java
+++ b/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/impl/TypedEventBusImpl.java
@@ -271,7 +271,7 @@ public class TypedEventBusImpl implements TypedEventBus {
 
         Long serviceId = getServiceId(properties);
 
-        doRemoveEventHandler(topicsToTypedHandlers, knownTypedHandlers, handler, serviceId);
+        doRemoveEventHandler(topicsToTypedHandlers, wildcardTopicsToTypedHandlers, knownTypedHandlers, handler, serviceId);
 
         synchronized (lock) {
             typedHandlersToTargetClasses.remove(handler);
@@ -282,7 +282,7 @@ public class TypedEventBusImpl implements TypedEventBus {
 
         Long serviceId = getServiceId(properties);
 
-        doRemoveEventHandler(topicsToUntypedHandlers, knownUntypedHandlers, handler, serviceId);
+        doRemoveEventHandler(topicsToUntypedHandlers, wildcardTopicsToUntypedHandlers, knownUntypedHandlers, handler, serviceId);
     }
 
     private Long getServiceId(Map<String, Object> properties) {
@@ -307,14 +307,20 @@ public class TypedEventBusImpl implements TypedEventBus {
         }
     }
 
-    private <T, U> void doRemoveEventHandler(Map<String, Map<T, U>> map, Map<Long, T> idMap, 
+    private <T, U> void doRemoveEventHandler(Map<String, Map<T, U>> map, Map<String, Map<T, U>> wildcardMap, Map<Long, T> idMap, 
             T handler, Long serviceId) {
         synchronized (lock) {
             List<String> consumed = knownHandlers.remove(serviceId);
-            knownHandlers.remove(serviceId);
+            idMap.remove(serviceId);
             if (consumed != null) {
                 consumed.forEach(s -> {
-                    Map<T, ?> handlers = map.get(s);
+                	Map<T, ?> handlers;
+                	if(isWildcard(s)) {
+                		handlers = wildcardMap.get(s.length() == 1 ? "" : s.substring(0, s.length() - 2));
+                	} else {
+                		handlers = map.get(s);
+                	}
+                	
                     if (handlers != null) {
                         handlers.remove(handler);
                         if (handlers.isEmpty()) {
@@ -350,7 +356,7 @@ public class TypedEventBusImpl implements TypedEventBus {
 
         synchronized (lock) {
             T handler = idToHandler.get(serviceId);
-            doRemoveEventHandler(map, idToHandler, handler, serviceId);
+			doRemoveEventHandler(map, wildcardMap, idToHandler, handler, serviceId);
             doAddEventHandler(map, wildcardMap, idToHandler, handler, defaultTopic, properties);
         }
     }

--- a/org.apache.aries.typedevent.bus/src/test/java/org/apache/aries/typedevent/bus/osgi/EventDeliveryIntegrationTest.java
+++ b/org.apache.aries.typedevent.bus/src/test/java/org/apache/aries/typedevent/bus/osgi/EventDeliveryIntegrationTest.java
@@ -18,6 +18,7 @@ package org.apache.aries.typedevent.bus.osgi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.osgi.service.typedevent.TypedEventConstants.TYPED_EVENT_TOPICS;
 
 import java.util.Dictionary;
 import java.util.HashMap;
@@ -224,6 +225,104 @@ public class EventDeliveryIntegrationTest extends AbstractIntegrationTest {
         assertEquals("foo", received.subEvent.message);
     }
     
-    
+    /**
+     * Tests that events are delivered to untyped Event Handlers
+     * based on topic
+     * 
+     * @throws InterruptedException
+     */
+    @Test
+    public void testEventReceivingUpdateTopic() throws InterruptedException {
+        
+        TestEvent event = new TestEvent();
+        event.message = "boo";
+        
+        Dictionary<String, Object> props = new Hashtable<>();
+        props.put(TYPED_EVENT_TOPICS, TEST_EVENT_TOPIC);
+        
+        regs.add(context.registerService(TypedEventHandler.class, typedEventHandler, props));
+
+        regs.add(context.registerService(UntypedEventHandler.class, untypedEventHandler, props));
+        
+        eventBus.deliver(event);
+        
+        Mockito.verify(typedEventHandler, Mockito.timeout(1000)).notify(
+                Mockito.eq(TEST_EVENT_TOPIC), Mockito.argThat(isTestEventWithMessage("boo")));
+
+        Mockito.verify(untypedEventHandler, Mockito.timeout(1000)).notifyUntyped(
+                Mockito.eq(TEST_EVENT_TOPIC), Mockito.argThat(isUntypedTestEventWithMessage("boo")));
+        
+        Mockito.clearInvocations(typedEventHandler, untypedEventHandler);
+        
+        props.put(TYPED_EVENT_TOPICS, TEST_EVENT_2_TOPIC);
+        
+        regs.forEach(s -> s.setProperties(props));
+        
+        eventBus.deliver(event);
+        
+        Mockito.verify(typedEventHandler, Mockito.after(1000).never()).notify(
+                Mockito.eq(TEST_EVENT_TOPIC), Mockito.any());
+        Mockito.verify(untypedEventHandler, Mockito.after(1000).never()).notifyUntyped(
+        		Mockito.eq(TEST_EVENT_TOPIC), Mockito.any());
+        
+        eventBus.deliver(TEST_EVENT_2_TOPIC, event);
+        
+        Mockito.verify(typedEventHandler, Mockito.timeout(1000)).notify(
+                Mockito.eq(TEST_EVENT_2_TOPIC), Mockito.argThat(isTestEventWithMessage("boo")));
+
+        Mockito.verify(untypedEventHandler, Mockito.timeout(1000)).notifyUntyped(
+                Mockito.eq(TEST_EVENT_2_TOPIC), Mockito.argThat(isUntypedTestEventWithMessage("boo")));
+        
+    }
+
+    /**
+     * Tests that events are delivered to untyped Event Handlers
+     * based on topic
+     * 
+     * @throws InterruptedException
+     */
+    @Test
+    public void testEventReceivingUpdateWildcardTopic() throws InterruptedException {
+    	
+    	TestEvent event = new TestEvent();
+    	event.message = "boo";
+    	
+    	Dictionary<String, Object> props = new Hashtable<>();
+    	props.put(TYPED_EVENT_TOPICS, "foo/bar/*");
+    	
+    	regs.add(context.registerService(TypedEventHandler.class, typedEventHandler, props));
+    	
+    	regs.add(context.registerService(UntypedEventHandler.class, untypedEventHandler, props));
+    	
+    	eventBus.deliver("foo/bar/foobar", event);
+    	
+    	Mockito.verify(typedEventHandler, Mockito.timeout(1000)).notify(
+    			Mockito.eq("foo/bar/foobar"), Mockito.argThat(isTestEventWithMessage("boo")));
+    	
+    	Mockito.verify(untypedEventHandler, Mockito.timeout(1000)).notifyUntyped(
+    			Mockito.eq("foo/bar/foobar"), Mockito.argThat(isUntypedTestEventWithMessage("boo")));
+    	
+    	Mockito.clearInvocations(typedEventHandler, untypedEventHandler);
+    	
+    	props.put(TYPED_EVENT_TOPICS, "foo/bar/foobar/*");
+    	
+    	regs.forEach(s -> s.setProperties(props));
+    	
+    	eventBus.deliver("foo/bar/foobar", event);
+    	
+    	Mockito.verify(typedEventHandler, Mockito.after(1000).never()).notify(
+    			Mockito.eq("foo/bar/foobar"), Mockito.any());
+    	Mockito.verify(untypedEventHandler, Mockito.after(1000).never()).notifyUntyped(
+    			Mockito.eq("foo/bar/foobar"), Mockito.any());
+    	
+    	eventBus.deliver("foo/bar/foobar/fizzbuzz", event);
+    	
+    	Mockito.verify(typedEventHandler, Mockito.timeout(1000)).notify(
+    			Mockito.eq("foo/bar/foobar/fizzbuzz"), Mockito.argThat(isTestEventWithMessage("boo")));
+    	
+    	Mockito.verify(untypedEventHandler, Mockito.timeout(1000)).notifyUntyped(
+    			Mockito.eq("foo/bar/foobar/fizzbuzz"), Mockito.argThat(isUntypedTestEventWithMessage("boo")));
+    	
+    }
     
 }


### PR DESCRIPTION
As part of the development of Typed Events 1.1.0 a new branch was created in Aries Typed Events to prototype the API. As part of that I found a few bugs, for which I am back porting the changes.

This will be ahead of another release of Aries Typed Events which will happen before the Typed Events 1.1.0 specification can be released.