### PR TITLE
Add support for an event conversion plugin

### DIFF
--- a/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/impl/EventConverter.java
+++ b/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/impl/EventConverter.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import org.apache.aries.typedevent.bus.spi.CustomEventConverter;
 import org.osgi.framework.Filter;
 import org.osgi.util.converter.Converter;
 import org.osgi.util.converter.ConverterFunction;
@@ -188,24 +189,27 @@ public class EventConverter {
     }
 
     private final Object originalEvent;
+    private final CustomEventConverter custom;
 
     private Map<String, ?> untypedEventDataForFiltering;
 
-    private EventConverter(Object event) {
+    private EventConverter(Object event, CustomEventConverter custom) {
         this.originalEvent = event;
+		this.custom = custom;
     }
 
-    private EventConverter(Map<String, ?> untypedEvent) {
+    private EventConverter(Map<String, ?> untypedEvent, CustomEventConverter custom) {
         this.originalEvent = untypedEvent;
+        this.custom = custom;
         this.untypedEventDataForFiltering = untypedEvent;
     }
 
-    public static EventConverter forTypedEvent(Object event) {
-        return new EventConverter(event);
+    public static EventConverter forTypedEvent(Object event, CustomEventConverter custom) {
+        return new EventConverter(event, custom);
     }
 
-    public static EventConverter forUntypedEvent(Map<String, ?> event) {
-        return new EventConverter(event);
+    public static EventConverter forUntypedEvent(Map<String, ?> event, CustomEventConverter custom) {
+        return new EventConverter(event, custom);
     }
 
     public boolean applyFilter(Filter f) {
@@ -221,16 +225,28 @@ public class EventConverter {
 
     public Map<String, ?> toUntypedEvent() {
         if (untypedEventDataForFiltering == null) {
-            untypedEventDataForFiltering = eventConverter.convert(originalEvent).sourceAsDTO().to(MAP_WITH_STRING_KEYS);
+        	if(custom == null || 
+        			(untypedEventDataForFiltering = custom.toUntypedEvent(originalEvent)) == null ) {
+        		untypedEventDataForFiltering = eventConverter.convert(originalEvent).sourceAsDTO().to(MAP_WITH_STRING_KEYS);
+        	}
         }
         return untypedEventDataForFiltering;
     }
 
-    public <T> T toTypedEvent(Class<T> clazz) {
-        if (clazz.isInstance(originalEvent)) {
-            return clazz.cast(originalEvent);
+    @SuppressWarnings("unchecked")
+	public <T> T toTypedEvent(TypeData targetEventClass) {
+        Class<?> rawType = targetEventClass.getRawType();
+        Type genericTarget = targetEventClass.getType();
+		if (rawType.isInstance(originalEvent) && rawType == genericTarget) {
+            return (T) originalEvent;
         } else {
-            return eventConverter.convert(originalEvent).targetAsDTO().to(clazz);
+        	if(custom != null) {
+				Object result = custom.toTypedEvent(originalEvent, rawType, genericTarget);
+				if(result != null) {
+					return (T) result;
+				}
+        	}
+            return eventConverter.convert(originalEvent).targetAsDTO().to(genericTarget);
         }
     }
 

--- a/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/impl/TypeData.java
+++ b/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/impl/TypeData.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.aries.typedevent.bus.impl;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+/**
+ *  The generic type information for the event data
+ */
+public final class TypeData {
+	
+	private final Class<?> rawType;
+	
+	private final Type type;
+
+	public TypeData(Type type) {
+		super();
+		this.type = type;
+		if(type instanceof Class) {
+			this.rawType = (Class<?>) type;
+		} else if (type instanceof ParameterizedType) {
+			this.rawType = (Class<?>) ((ParameterizedType) type).getRawType();
+		} else {
+			throw new IllegalArgumentException("The type " + type + 
+					" is not acceptable. Must be a raw Class or Parameterized Type");
+		}
+	}
+
+	public Class<?> getRawType() {
+		return rawType;
+	}
+
+	public Type getType() {
+		return type;
+	}
+}

--- a/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/impl/TypedEventBusActivator.java
+++ b/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/impl/TypedEventBusActivator.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 
 import org.apache.aries.component.dsl.OSGi;
 import org.apache.aries.component.dsl.OSGiResult;
+import org.apache.aries.typedevent.bus.spi.AriesTypedEvents;
 import org.osgi.annotation.bundle.Header;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -123,7 +124,9 @@ public class TypedEventBusActivator implements BundleActivator {
                                                                     getServiceProps(csr.getServiceReference())),
                                                          handler -> tebi.removeUnhandledEventHandler(handler,
                                                                     getServiceProps(csr.getServiceReference())))),
-                                register(TypedEventBus.class, tebi, serviceProps)
+                                register(new String[] { 
+                        				TypedEventBus.class.getName(), AriesTypedEvents.class.getName()
+                        			}, tebi, serviceProps)
                                         .flatMap(x -> nothing())));
 
 

--- a/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/impl/TypedEventTask.java
+++ b/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/impl/TypedEventTask.java
@@ -21,13 +21,13 @@ import org.osgi.service.typedevent.TypedEventHandler;
 
 class TypedEventTask extends EventTask {
     private final String topic;
-    private final Class<?> targetEventClass;
+    private final TypeData targetEventClass;
     private final EventConverter eventData;
     private final TypedEventHandler<Object> eventProcessor;
 
     @SuppressWarnings("unchecked")
     public TypedEventTask(String topic, EventConverter eventData, TypedEventHandler<?> eventProcessor,
-            Class<?> targetEventClass) {
+            TypeData targetEventClass) {
         super();
         this.topic = topic;
         this.targetEventClass = targetEventClass;

--- a/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/spi/AriesTypedEvents.java
+++ b/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/spi/AriesTypedEvents.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.aries.typedevent.bus.spi;
+
+import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.service.typedevent.TypedEventBus;
+
+@ProviderType
+public interface AriesTypedEvents extends TypedEventBus {
+	
+	/**
+	 * Register a global event converter for this event bus. Equivalent to
+	 * {@link #registerGlobalEventConverter(CustomEventConverter, boolean)} passing
+	 * <code>false</code> as the <em>force</em> flag.
+	 * @param converter the converter to register
+	 * @throws IllegalStateException if a converter has already been registered
+	 */
+	default public void registerGlobalEventConverter(CustomEventConverter converter) throws IllegalStateException {
+		registerGlobalEventConverter(converter, false);
+	}
+
+	/**
+	 * Register a global event converter for this event bus.
+	 * @param converter - the converter to register
+	 * @param force - if true then any existing converter will be replaced
+	 * @throws IllegalStateException if <em>force</em> is <code>false</code> 
+	 * and a converter has already been registered
+	 */
+	public void registerGlobalEventConverter(CustomEventConverter converter, boolean force) throws IllegalStateException;
+
+}

--- a/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/spi/CustomEventConverter.java
+++ b/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/spi/CustomEventConverter.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.aries.typedevent.bus.spi;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ConsumerType;
+
+/**
+ * A Custom Event Converter can be registered to provide customised
+ * conversion of event data.
+ */
+@ConsumerType
+public interface CustomEventConverter {
+	/**
+	 * Convert the supplied event to the target type
+	 * @param event - the event to convert
+	 * @param rawTarget - the target class
+	 * @param genericTarget - the target type, including any generics information
+	 * @return A converted event, or <code>null</code> if the event cannot be converted
+	 */
+	public <T> T toTypedEvent(Object event, Class<?> rawTarget, Type genericTarget);
+	
+	/**
+	 * Convert the supplied event to an untyped event (nested maps of scalar types)
+	 * @param event - the event to convert
+	 * @return A converted event, or <code>null</code> if the event cannot be converted
+	 */
+	public Map<String, Object> toUntypedEvent(Object event);
+}

--- a/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/spi/package-info.java
+++ b/org.apache.aries.typedevent.bus/src/main/java/org/apache/aries/typedevent/bus/spi/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@org.osgi.annotation.bundle.Export
+package org.apache.aries.typedevent.bus.spi;


### PR DESCRIPTION
Event Conversion is left up to the implementation, and Aries uses the OSGi converter. There are, however, users that want to use richer types than are supported by the specification. They should be able to register an override which lets them perform the conversion that they need.