### PR TITLE
Update to version 1.0.0-SNAPSHOT for built bundles

### DIFF
--- a/org.apache.aries.typedevent.bus/pom.xml
+++ b/org.apache.aries.typedevent.bus/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.apache.aries.typedevent</groupId>
         <artifactId>typedevent-parent</artifactId>
-        <version>0.0.3-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     

--- a/org.apache.aries.typedevent.bus/run.bndrun
+++ b/org.apache.aries.typedevent.bus/run.bndrun
@@ -31,7 +31,7 @@
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.util.converter;version='[1.0.9,1.0.10)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\

--- a/org.apache.aries.typedevent.bus/test.bndrun
+++ b/org.apache.aries.typedevent.bus/test.bndrun
@@ -54,6 +54,6 @@
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	slf4j.api;version='[1.7.30,1.7.31)',\
-	org.apache.aries.typedevent.bus;version='[0.0.3,0.0.4)',\
-	org.apache.aries.typedevent.bus-tests;version='[0.0.3,0.0.4)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
+	org.apache.aries.typedevent.bus-tests;version='[1.0.0,1.0.1)',\
 	org.mockito.junit-jupiter;version='[5.5.0,5.5.1)'

--- a/org.apache.aries.typedevent.remote/org.apache.aries.typedevent.remote.api/pom.xml
+++ b/org.apache.aries.typedevent.remote/org.apache.aries.typedevent.remote.api/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.apache.aries.typedevent</groupId>
         <artifactId>typedevent-parent</artifactId>
-        <version>0.0.3-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     

--- a/org.apache.aries.typedevent.remote/org.apache.aries.typedevent.remote.remoteservices/pom.xml
+++ b/org.apache.aries.typedevent.remote/org.apache.aries.typedevent.remote.remoteservices/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.apache.aries.typedevent</groupId>
         <artifactId>typedevent-parent</artifactId>
-        <version>0.0.3-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <groupId>org.apache.aries.typedevent.remote.remoteservices</groupId>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.apache.aries.typedevent.remote</groupId>
             <artifactId>org.apache.aries.typedevent.remote.spi</artifactId>
-            <version>0.0.3-SNAPSHOT</version>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.apache.aries.typedevent</groupId>
             <artifactId>org.apache.aries.typedevent.bus</artifactId>
-            <version>0.0.3-SNAPSHOT</version>
+            <version>1.0.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/org.apache.aries.typedevent.remote/org.apache.aries.typedevent.remote.remoteservices/test.bndrun
+++ b/org.apache.aries.typedevent.remote/org.apache.aries.typedevent.remote.remoteservices/test.bndrun
@@ -52,8 +52,8 @@
 	org.opentest4j;version='[1.3.0,1.3.1)',\
 	org.osgi.test.common;version='[1.2.1,1.2.2)',\
 	org.osgi.test.junit5;version='[1.2.1,1.2.2)',\
-	org.apache.aries.typedevent.bus;version='[0.0.3,0.0.4)',\
-	org.apache.aries.typedevent.remote.api;version='[0.0.3,0.0.4)',\
-	org.apache.aries.typedevent.remote.remoteservices;version='[0.0.3,0.0.4)',\
-	org.apache.aries.typedevent.remote.remoteservices-tests;version='[0.0.3,0.0.4)',\
-	org.apache.aries.typedevent.remote.spi;version='[0.0.3,0.0.4)'
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
+	org.apache.aries.typedevent.remote.api;version='[1.0.0,1.0.1)',\
+	org.apache.aries.typedevent.remote.remoteservices;version='[1.0.0,1.0.1)',\
+	org.apache.aries.typedevent.remote.remoteservices-tests;version='[1.0.0,1.0.1)',\
+	org.apache.aries.typedevent.remote.spi;version='[1.0.0,1.0.1)'

--- a/org.apache.aries.typedevent.remote/org.apache.aries.typedevent.remote.spi/pom.xml
+++ b/org.apache.aries.typedevent.remote/org.apache.aries.typedevent.remote.spi/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.apache.aries.typedevent</groupId>
         <artifactId>typedevent-parent</artifactId>
-        <version>0.0.3-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.aries.typedevent.remote</groupId>
             <artifactId>org.apache.aries.typedevent.remote.api</artifactId>
-            <version>0.0.3-SNAPSHOT</version>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     

--- a/org.apache.aries.typedevent.remote/pom.xml
+++ b/org.apache.aries.typedevent.remote/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.apache.aries.typedevent</groupId>
         <artifactId>typedevent-parent</artifactId>
-        <version>0.0.3-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     
     <groupId>org.apache.aries.typedevent.remote</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.apache.aries.typedevent</groupId>
     <artifactId>typedevent-parent</artifactId>
-    <version>0.0.3-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Apache Aries Typed Events Parent.</description>
     <scm>

--- a/typedevent-test-bom/pom.xml
+++ b/typedevent-test-bom/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.apache.aries.typedevent</groupId>
         <artifactId>typedevent-parent</artifactId>
-        <version>0.0.3-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>typedevent-test-bom</artifactId>
     <packaging>pom</packaging>


### PR DESCRIPTION
The Aries Typed Events implementation of OSGi Type Safe Events 1.0.0 has never had a 1.0.0 release. This should be rectified as it is both stable, and used by other projects